### PR TITLE
removed CVMFS servers in the US and Europe

### DIFF
--- a/ansible/roles/neurodesk/files/cvmfs/config.d/neurodesk.ardc.edu.au.conf
+++ b/ansible/roles/neurodesk/files/cvmfs/config.d/neurodesk.ardc.edu.au.conf
@@ -1,3 +1,3 @@
 CVMFS_USE_GEOAPI=yes
-CVMFS_SERVER_URL="http://203.101.231.144/cvmfs/@fqrn@;http://150.136.239.221/cvmfs/@fqrn@;http://132.145.96.34/cvmfs/@fqrn@;http://140.238.170.185/cvmfs/@fqrn@;http://130.61.74.69/cvmfs/@fqrn@;http://152.67.114.42/cvmfs/@fqrn@"
+CVMFS_SERVER_URL="http://203.101.231.144/cvmfs/@fqrn@;http://152.67.114.42/cvmfs/@fqrn@"
 CVMFS_KEYS_DIR="/etc/cvmfs/keys/ardc.edu.au/"


### PR DESCRIPTION
I removed the CVMFS servers in the US and Europe and kept the two Australian mirror servers:
203.101.231.144 (nectar cloud brisbane)
152.67.114.42 (oracle cloud sydney)