### PR TITLE
add link to desktop to uploads

### DIFF
--- a/ansible/roles/neurodesk/tasks/main.yml
+++ b/ansible/roles/neurodesk/tasks/main.yml
@@ -51,12 +51,18 @@
     path: /etc/skel/Desktop
     state: directory
 
-- name: Create a symbolic link
+- name: Create a symbolic link to neurodesktop-storage
   file:
     src: /neurodesktop-storage
     dest: /etc/skel/Desktop/neurodesktop-storage
     state: link
-
+- name: Create a symbolic link
+  file:
+    src: /home/vdiuser/thinclient_drives/GUACFS
+    dest: /etc/skel/Desktop/transfer
+    state: link
+    
+    
 #TODO(andybotting): Not needed outside a container?
 # Allow the root user to access the sshfs mount
 # https://github.com/NeuroDesk/neurodesk/issues/47

--- a/ansible/roles/neurodesk/tasks/main.yml
+++ b/ansible/roles/neurodesk/tasks/main.yml
@@ -56,11 +56,12 @@
     src: /neurodesktop-storage
     dest: /etc/skel/Desktop/neurodesktop-storage
     state: link
-- name: Create a symbolic link
+- name: Create a symbolic link to upload directory (has to be forced because home does not yet exist at buildtime)
   file:
     src: /home/vdiuser/thinclient_drives/GUACFS
     dest: /etc/skel/Desktop/transfer
     state: link
+    force: true
     
     
 #TODO(andybotting): Not needed outside a container?


### PR DESCRIPTION
Users are confused where their files are when uploading through drag and drop. Hoping that creating a link on the desktop helps.